### PR TITLE
conformity with stricter pycodestyle

### DIFF
--- a/tests/test_fancies_dump.py
+++ b/tests/test_fancies_dump.py
@@ -2,8 +2,7 @@ import re
 from unittest import TestCase, main
 
 from bronx.fancies import dump
-from bronx.fancies.dump import TxtDumper, JsonableDumper, XmlDomDumper,\
-    OneLineTxtDumper
+from bronx.fancies.dump import TxtDumper, JsonableDumper, XmlDomDumper, OneLineTxtDumper
 
 
 class Foo:


### PR DESCRIPTION
Pycodestyle devient un peu  plus strict.
Les changements similaires côté VORTEX ont été faits et mergés déjà dans olive-dev.